### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@ A Sinatra template for Heroku (and heroku-docker!) with some extra goodies inclu
 
 This repository ~~rips~~ takes a page out of Heroku's book of "getting started" repositories; it provides a scaffold for a Sinatra app that you can run out of the box with standard Heroku tools. Heroku provides a couple of fantastic starting points for a variety of platforms on [GitHub][1], including a [Rails app][2]. This is just a Sinatra variation on the theme.
 
-## *caveat emptor*: opinions abound here
-This repository includes a bunch of tools that I find useful. You may not want them!
+***caveat emptor:*** This repository includes a bunch of tools that I *personally* find useful. You probably have opinions of your own, and you may not want them!
 
 * **RSpec** for behavior-driven design
 * **Pry** for a better REPL
@@ -43,9 +42,7 @@ Contributions are always welcome. Submit a pull request or send me an email with
 
 This project is released under the MIT license.
 
-Jordan Ryan Reuter
-
-<mailto:me@jreut.com>
+Jordan Ryan Reuter (<mailto:me@jreut.com>)
 
 [1]: https://github.com/heroku
 [2]: https://github.com/heroku/ruby-getting-started

--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@ A Sinatra template for Heroku (and heroku-docker!) with some extra goodies inclu
 This repository ~~rips~~ takes a page out of Heroku's book of "getting started" repositories; it provides a scaffold for a Sinatra app that you can run out of the box with standard Heroku tools. Heroku provides a couple of fantastic starting points for a variety of platforms on [GitHub][1], including a [Rails app][2]. This is just a Sinatra variation on the theme.
 
 ## *caveat emptor*: opinions abound here
-While the `master` branch of this repository contains pretty much a blank slate Sinatra app, the `opinionated` branch includes some tools I find useful:
+This repository includes a bunch of tools that I find useful. You may not want them!
 
-* RSpec
-* Pry
+* **RSpec** for behavior-driven design
+* **Pry** for a better REPL
+* **Guard** for filesystem-aware automation (in this case, of test running)
 
 ## Using Docker
 Heroku's [heroku-docker plugin][3] is a fantastic way to get the best of both worlds: easy local development with Docker and (almost) foolproof production on Heroku. All you need to start is the [Heroku Toolbelt][4].


### PR DESCRIPTION
- update list of opinionated tools
- because the `opinionated` branch no longer exists, remove that line
